### PR TITLE
Fix unit tests by mocking sdk dependencies

### DIFF
--- a/src/test/groovy/com/intellij/debugger/engine/MockSuspendContext.groovy
+++ b/src/test/groovy/com/intellij/debugger/engine/MockSuspendContext.groovy
@@ -1,0 +1,16 @@
+package com.intellij.debugger.engine
+
+import com.sun.jdi.event.EventSet
+import org.jetbrains.annotations.NotNull
+
+class MockSuspendContext extends SuspendContextImpl {
+
+    MockSuspendContext(@NotNull DebugProcessImpl debugProcess, int suspendPolicy, int eventVotes, EventSet set) {
+        super(debugProcess, suspendPolicy, eventVotes, set)
+    }
+
+    @Override
+    protected void resumeImpl() {
+
+    }
+}

--- a/src/test/groovy/com/vgaidarji/objectexporter/DebuggerToObjectTest.groovy
+++ b/src/test/groovy/com/vgaidarji/objectexporter/DebuggerToObjectTest.groovy
@@ -1,21 +1,27 @@
 package com.vgaidarji.objectexporter
 
+import com.intellij.debugger.engine.DebugProcessImpl
 import com.intellij.debugger.engine.JavaValue
+import com.intellij.debugger.engine.MockSuspendContext
+import com.intellij.debugger.engine.SuspendContextImpl
 import com.intellij.debugger.engine.evaluation.EvaluationContextImpl
-import com.intellij.debugger.ui.impl.watch.ArgumentValueDescriptorImpl
-import com.intellij.debugger.ui.impl.watch.NodeManagerImpl
+import com.intellij.debugger.settings.NodeRendererSettings
 import com.intellij.debugger.ui.impl.watch.ValueDescriptorImpl
-import com.intellij.mock.MockProjectEx
-import com.intellij.testFramework.LightCodeInsightTestCase
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.extensions.Extensions
+import com.intellij.openapi.project.Project
 import com.intellij.xdebugger.impl.ui.tree.XDebuggerTree
 import com.intellij.xdebugger.impl.ui.tree.nodes.XValueNodeImpl
 import com.sun.jdi.PrimitiveValue
 import com.sun.tools.jdi.MyIntegerValueImpl
 import com.sun.tools.jdi.MyVirtualMachineImpl
-import org.junit.Ignore
+import com.vgaidarji.objectexporter.mock.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import org.picocontainer.PicoContainer
 
 import javax.swing.tree.TreePath
 import javax.swing.tree.TreeSelectionModel
@@ -26,6 +32,10 @@ import static org.mockito.Mockito.when
 @RunWith(JUnit4)
 class DebuggerToObjectTest extends GroovyTestCase {
     private MyVirtualMachineImpl virtualMachine
+    private Disposable disposable
+    private PicoContainer picoContainer
+    private Application application
+    private Project project
 
     @Override
     void setUp() {
@@ -33,7 +43,6 @@ class DebuggerToObjectTest extends GroovyTestCase {
         virtualMachine = mock(MyVirtualMachineImpl)
     }
 
-    @Ignore("find a way to prepare `JavaValue` object for test")
     @Test
     void toObject_shouldExtractPrimitive() {
         DebuggerTreeToObject extractor = new DebuggerTreeToObject()
@@ -50,7 +59,7 @@ class DebuggerToObjectTest extends GroovyTestCase {
     }
 
     private XDebuggerTree createDebuggerTreeWithPrimitive(PrimitiveType type, String name,
-            PrimitiveValue value) {
+                                                          PrimitiveValue value) {
         XDebuggerTree tree = mock(XDebuggerTree)
         TreeSelectionModel treeSelectionModel = mock(TreeSelectionModel)
         TreePath treePath = mock(TreePath)
@@ -62,15 +71,31 @@ class DebuggerToObjectTest extends GroovyTestCase {
         tree
     }
 
-    private JavaValue preparePrimitive(PrimitiveType type, String name,
-            PrimitiveValue value) {
-        // TODO: find a way to prepare `JavaValue` object for test
-        ValueDescriptorImpl valueDescriptor = mock(ValueDescriptorImpl.class)
-        JavaValue javaValue = mock(JavaValue)
-        when(valueDescriptor.getType()).thenReturn(type)
-        when(valueDescriptor.getValue()).thenReturn(value)
-        when(javaValue.getDescriptor()).thenReturn(valueDescriptor)
-        when(javaValue.getName()).thenReturn(name)
-        javaValue
+
+    private JavaValue preparePrimitive(PrimitiveType type, String name, PrimitiveValue value) {
+        mockDependencies()
+        DebugProcessImpl debugProcess = new MockDebugProcess(project)
+        SuspendContextImpl suspendContext = new MockSuspendContext(debugProcess, 0, 0, null)
+        EvaluationContextImpl evaluationContext = new EvaluationContextImpl(suspendContext, null, null)
+        ValueDescriptorImpl descriptor = createValueDescriptor(type, name, value)
+        new MockJavaValue(descriptor, evaluationContext)
+    }
+
+    private void mockDependencies() {
+        Extensions.registerAreaClass("IDEA_PROJECT", null);
+        disposable = new MockDisposable()
+        picoContainer = new MockPicoContainer()
+        application = new MockApplication(picoContainer, disposable)
+        application.addComponent(NodeRendererSettings, mock(NodeRendererSettings))
+        ApplicationManager.setApplication(application, disposable)
+    }
+
+
+    private ValueDescriptorImpl createValueDescriptor(PrimitiveType type, String name, PrimitiveValue value) {
+        ValueDescriptorImpl valueDescriptor = new MockDescriptor(project)
+        valueDescriptor.value = value
+        valueDescriptor.type = type
+        valueDescriptor.name = name
+        valueDescriptor
     }
 }

--- a/src/test/groovy/com/vgaidarji/objectexporter/mock/MockApplication.java
+++ b/src/test/groovy/com/vgaidarji/objectexporter/mock/MockApplication.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2000-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vgaidarji.objectexporter.mock;
+
+import com.intellij.mock.MockComponentManager;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.*;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.util.Condition;
+import com.intellij.openapi.util.ThrowableComputable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.ide.PooledThreadExecutor;
+import org.picocontainer.PicoContainer;
+
+import java.awt.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+public class MockApplication extends MockComponentManager implements Application {
+    public static int INSTANCES_CREATED = 0;
+
+    public MockApplication(@Nullable PicoContainer parent, @NotNull Disposable parentDisposable) {
+        super(parent, parentDisposable);
+        INSTANCES_CREATED++;
+    }
+
+    @Override
+    public boolean isInternal() {
+        return false;
+    }
+
+    @Override
+    public boolean isEAP() {
+        return false;
+    }
+
+    @Override
+    public boolean isDispatchThread() {
+        return true;
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
+    public void assertReadAccessAllowed() {
+    }
+
+    @Override
+    public void assertWriteAccessAllowed() {
+    }
+
+    @Override
+    public void assertIsDispatchThread() {
+    }
+
+    @Override
+    public boolean isReadAccessAllowed() {
+        return true;
+    }
+
+    @Override
+    public boolean isWriteAccessAllowed() {
+        return true;
+    }
+
+    @Override
+    public boolean isUnitTestMode() {
+        return true;
+    }
+
+    @Override
+    public boolean isHeadlessEnvironment() {
+        return true;
+    }
+
+    @Override
+    public boolean isCommandLine() {
+        return true;
+    }
+
+    @NotNull
+    @Override
+    public Future<?> executeOnPooledThread(@NotNull Runnable action) {
+        return PooledThreadExecutor.INSTANCE.submit(action);
+    }
+
+    @NotNull
+    @Override
+    public <T> Future<T> executeOnPooledThread(@NotNull Callable<T> action) {
+        return PooledThreadExecutor.INSTANCE.submit(action);
+    }
+
+    @Override
+    public boolean isDisposeInProgress() {
+        return false;
+    }
+
+    @Override
+    public boolean isRestartCapable() {
+        return false;
+    }
+
+    @Override
+    public void restart() {
+    }
+
+    @Override
+    public void runReadAction(@NotNull Runnable action) {
+        action.run();
+    }
+
+    @Override
+    public <T> T runReadAction(@NotNull Computable<T> computation) {
+        return computation.compute();
+    }
+
+    @Override
+    public <T, E extends Throwable> T runReadAction(@NotNull ThrowableComputable<T, E> computation) throws E {
+        return computation.compute();
+    }
+
+    @Override
+    public void runWriteAction(@NotNull Runnable action) {
+        action.run();
+    }
+
+    @Override
+    public <T> T runWriteAction(@NotNull Computable<T> computation) {
+        return computation.compute();
+    }
+
+    @Override
+    public <T, E extends Throwable> T runWriteAction(@NotNull ThrowableComputable<T, E> computation) throws E {
+        return computation.compute();
+    }
+
+    @NotNull
+    @Override
+    public AccessToken acquireReadActionLock() {
+        return AccessToken.EMPTY_ACCESS_TOKEN;
+    }
+
+    @NotNull
+    @Override
+    public AccessToken acquireWriteActionLock(@Nullable Class marker) {
+        return AccessToken.EMPTY_ACCESS_TOKEN;
+    }
+
+    @Override
+    public boolean hasWriteAction(@NotNull Class<?> actionClass) {
+        return false;
+    }
+
+    @Override
+    public void addApplicationListener(@NotNull ApplicationListener listener) {
+    }
+
+    @Override
+    public void addApplicationListener(@NotNull ApplicationListener listener, @NotNull Disposable parent) {
+    }
+
+    @Override
+    public void removeApplicationListener(@NotNull ApplicationListener listener) {
+    }
+
+    @Override
+    public long getStartTime() {
+        return 0;
+    }
+
+    @Override
+    public long getIdleTime() {
+        return 0;
+    }
+
+    @NotNull
+    @Override
+    public ModalityState getNoneModalityState() {
+        return ModalityState.NON_MODAL;
+    }
+
+    @Override
+    public void invokeLater(@NotNull final Runnable runnable, @NotNull final Condition expired) {
+    }
+
+    @Override
+    public void invokeLater(@NotNull final Runnable runnable, @NotNull final ModalityState state, @NotNull final Condition expired) {
+    }
+
+    @Override
+    public void invokeLater(@NotNull Runnable runnable) {
+    }
+
+    @Override
+    public void invokeLater(@NotNull Runnable runnable, @NotNull ModalityState state) {
+    }
+
+    @Override
+    @NotNull
+    public ModalityInvokator getInvokator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void invokeAndWait(@NotNull Runnable runnable, @NotNull ModalityState modalityState) {
+    }
+
+    @Override
+    public void invokeAndWait(@NotNull Runnable runnable) throws ProcessCanceledException {
+        invokeAndWait(runnable, getDefaultModalityState());
+    }
+
+    @NotNull
+    @Override
+    public ModalityState getCurrentModalityState() {
+        return getNoneModalityState();
+    }
+
+    @NotNull
+    @Override
+    public ModalityState getAnyModalityState() {
+        return getNoneModalityState();
+    }
+
+    @NotNull
+    @Override
+    public ModalityState getModalityStateForComponent(@NotNull Component c) {
+        return getNoneModalityState();
+    }
+
+    @NotNull
+    @Override
+    public ModalityState getDefaultModalityState() {
+        return getNoneModalityState();
+    }
+
+    @Override
+    public void exit() {
+    }
+
+    @Override
+    public void saveAll() {
+    }
+
+    @Override
+    public void saveSettings() {
+    }
+}

--- a/src/test/groovy/com/vgaidarji/objectexporter/mock/MockDebugProcess.groovy
+++ b/src/test/groovy/com/vgaidarji/objectexporter/mock/MockDebugProcess.groovy
@@ -1,0 +1,11 @@
+package com.vgaidarji.objectexporter.mock
+
+import com.intellij.debugger.engine.DebugProcessImpl
+import com.intellij.openapi.project.Project
+
+class MockDebugProcess extends DebugProcessImpl {
+
+     MockDebugProcess(Project project) {
+        super(project)
+    }
+}

--- a/src/test/groovy/com/vgaidarji/objectexporter/mock/MockDescriptor.groovy
+++ b/src/test/groovy/com/vgaidarji/objectexporter/mock/MockDescriptor.groovy
@@ -1,0 +1,49 @@
+package com.vgaidarji.objectexporter.mock
+
+import com.intellij.debugger.DebuggerContext
+import com.intellij.debugger.engine.evaluation.EvaluateException
+import com.intellij.debugger.engine.evaluation.EvaluationContextImpl
+import com.intellij.debugger.ui.impl.watch.ValueDescriptorImpl
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiExpression
+import com.sun.jdi.Type
+import com.sun.jdi.Value
+import com.sun.jdi.VirtualMachine
+
+
+class MockDescriptor extends ValueDescriptorImpl {
+
+    Value value
+    Type type
+    String name
+
+    MockDescriptor(Project project) {
+        super(project)
+    }
+
+    @Override
+    Value calcValue(EvaluationContextImpl evaluationContext) throws EvaluateException {
+        return null
+    }
+
+    @Override
+    String calcValueName() {
+        return name
+    }
+
+    @Override
+    PsiExpression getDescriptorEvaluation(DebuggerContext context) throws EvaluateException {
+        return null
+    }
+
+    @Override
+    Type getType() {
+        return type
+    }
+
+    @Override
+    Value getValue() {
+        return value
+    }
+
+}

--- a/src/test/groovy/com/vgaidarji/objectexporter/mock/MockDisposable.groovy
+++ b/src/test/groovy/com/vgaidarji/objectexporter/mock/MockDisposable.groovy
@@ -1,0 +1,10 @@
+package com.vgaidarji.objectexporter.mock;
+
+import com.intellij.openapi.Disposable;
+
+class MockDisposable implements Disposable {
+
+    @Override
+    void dispose() {
+    }
+}

--- a/src/test/groovy/com/vgaidarji/objectexporter/mock/MockJavaValue.groovy
+++ b/src/test/groovy/com/vgaidarji/objectexporter/mock/MockJavaValue.groovy
@@ -1,0 +1,15 @@
+package com.vgaidarji.objectexporter.mock
+
+import com.intellij.debugger.engine.JavaValue
+import com.intellij.debugger.engine.evaluation.EvaluationContextImpl
+import com.intellij.debugger.ui.impl.watch.ValueDescriptorImpl
+import org.jetbrains.annotations.NotNull
+
+class MockJavaValue extends JavaValue {
+
+    MockJavaValue(@NotNull ValueDescriptorImpl valueDescriptor,
+                            @NotNull EvaluationContextImpl evaluationContext) {
+        super(null, valueDescriptor, evaluationContext, null, false)
+    }
+
+}

--- a/src/test/groovy/com/vgaidarji/objectexporter/mock/MockPicoContainer.groovy
+++ b/src/test/groovy/com/vgaidarji/objectexporter/mock/MockPicoContainer.groovy
@@ -1,0 +1,107 @@
+package com.vgaidarji.objectexporter.mock
+
+import com.intellij.debugger.settings.NodeRendererSettings
+import com.intellij.openapi.fileTypes.MockFileTypeManager
+import org.picocontainer.*
+
+class MockPicoContainer implements PicoContainer {
+
+    @Override
+    Object getComponentInstance(Object o) {
+        if (o == NodeRendererSettings.class.name) {
+            new NodeRendererSettings()
+        } else {
+            new MockFileTypeManager()
+        }
+    }
+
+    @Override
+    ComponentAdapter getComponentAdapter(Object o) {
+        return new ComponentAdapter() {
+            @Override
+            Object getComponentKey() {
+                return o
+            }
+
+            @Override
+            Class getComponentImplementation() {
+                return null
+            }
+
+            @Override
+            Object getComponentInstance(PicoContainer picoContainer) throws PicoInitializationException, PicoIntrospectionException {
+                return null
+            }
+
+            @Override
+            void verify(PicoContainer picoContainer) throws PicoIntrospectionException {
+
+            }
+
+            @Override
+            void accept(PicoVisitor picoVisitor) {
+
+            }
+        }
+    }
+
+    @Override
+    Object getComponentInstanceOfType(Class aClass) {
+        return null
+    }
+
+    @Override
+    List getComponentInstances() {
+        return null
+    }
+
+    @Override
+    PicoContainer getParent() {
+        return null
+    }
+
+    @Override
+    ComponentAdapter getComponentAdapterOfType(Class aClass) {
+        return null
+    }
+
+    @Override
+    Collection getComponentAdapters() {
+        return null
+    }
+
+    @Override
+    List getComponentAdaptersOfType(Class aClass) {
+        return null
+    }
+
+    @Override
+    void verify() throws PicoVerificationException {
+
+    }
+
+    @Override
+    List getComponentInstancesOfType(Class aClass) {
+        return null
+    }
+
+    @Override
+    void accept(PicoVisitor picoVisitor) {
+
+    }
+
+    @Override
+    void dispose() {
+
+    }
+
+    @Override
+    void start() {
+
+    }
+
+    @Override
+    void stop() {
+
+    }
+}


### PR DESCRIPTION
Closes #1
Mocks are provided for missing SDK dependencies. Class MockApplication is Java class since it's just a copy of SDK provided MockApplication class with slightly changes in constructor. 